### PR TITLE
Elasticsearch disclaimer to include 6.2

### DIFF
--- a/doc_source/create-destination.md
+++ b/doc_source/create-destination.md
@@ -70,7 +70,7 @@ To use the default prefix for source record backup, leave this option blank\. Ki
 This section describes options for using Amazon ES for your destination\.
 
 **Important**  
-Kinesis Firehose doesn't currently support Elasticsearch 6\.0\. Data delivery from Kinesis Firehose to Elasticsearch 6\.0 fails\.
+Kinesis Firehose doesn't currently support Elasticsearch 6\.x\. Data delivery from Kinesis Firehose to Elasticsearch 6\.x fails\.
 
 **To choose Amazon ES for your destination**
 


### PR DESCRIPTION
*Issue #, if available:*
\-

*Description of changes:*
Firehose does not work with ES 6.0. It does not work with ES 6.2 either.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.